### PR TITLE
Set ETCD_UNSUPPORTED_ARCH to ARM64

### DIFF
--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -4,6 +4,7 @@ ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/
 ADD var/etcd /var/etcd
 ADD var/lib/etcd /var/lib/etcd
+ENV ETCD_UNSUPPORTED_ARCH=arm64
 
 EXPOSE 2379 2380
 


### PR DESCRIPTION

Hi,

Package Owner: Mohneesh Jha
PR change Details:

#Patch Details : Docker-release.arm64 has been modified :

Docker-release.arm64: The  ETCD_UNSUPPORTED_ARCH environment is set to arm64

#Testing Detail :
The testing is done over travis

#Reviewer Comment : < To be filled by Reviewer >

#PR Description :
Here is my commit message : Setting ETCD_UNSUPPORTED_ARCH Environment To Arm64
Body of PR :
>> 
Signed-off-by: odidev@puresoftware.com.

#Reviewer: Pruthvi Teja and Rajeev Nayan

Thanks,
Mohneesh Jha